### PR TITLE
[Fix] 메인페이지 컴포넌트 구조 변경

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,18 @@ export default {
 }
 </script>
 
-<style lang="stylus">
+<style>
+.bd-placeholder-img {
+  font-size: 1.125rem;
+  text-anchor: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
 
+@media (min-width: 768px) {
+  .bd-placeholder-img-lg {
+    font-size: 3.5rem;
+  }
+}
 </style>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -56,9 +56,6 @@
           <p>
             <a href="/" class="text-reset">Tech</a>
           </p>
-          <p>
-            <a href="/about" class="text-reset">Help</a>
-          </p>
           
         </div>
         <!-- Grid column -->

--- a/src/components/RecordList.vue
+++ b/src/components/RecordList.vue
@@ -1,5 +1,6 @@
 <template>
-    <div class="col mb-2" v-if="records.length !== 0">
+    <div class="col mb-2" >
+        <div class="container d-flex flex-column justify-content-center min-vh-100" v-if="records.length !== 0">
         <!-- 게시글 카드 4개씩 페이지네이션  -->
         <div class="row-md-5 text-start" v-for="record, idx in records" :key="record.record_id">
             <div class="row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative"
@@ -14,16 +15,31 @@
                 </div>
             </div>
         </div>
+        
     </div>
-    <div class="col mb-2" v-else>
-        아직 작성된 게시글이 없습니다.
+    <div class="container text-center d-flex flex-column justify-content-center min-vh-100" v-else >
+        <p id="empty">아직 작성된 게시글이 없습니다.</p>
     </div>
+    <nav aria-label="Page navigation example" class="col" v-if="records.length !== 0">
+            <ul class="pagination justify-content-center">
+                <li class="page-item" v-for="idx in page" :key="idx"><a class="page-link" @click="fetchData(Number(idx))">{{
+                    idx
+                }}</a></li>
+            </ul>
+        </nav>
+    <div class="col text-end">
+            <button type="button" class="btn btn-outline-secondary me-2" @click="createData()" v-if="loggedIn">글쓰기</button>
+    </div>
+    </div>
+    
 </template>
 
 <script lang="ts">
-import { PropType, ref } from 'vue';
+import { computed, onMounted, PropType, ref } from 'vue';
 import { useStore } from 'vuex';
-import RecordType from '@/types/RecordType';
+import RecordType, { RecordReqParam } from '@/types/RecordType';
+import router from '@/router';
+import { authComputed } from '@/store/helper';
 
 export default {
     name: 'RecordList',
@@ -33,18 +49,47 @@ export default {
             type: Array as PropType<RecordType[]>,
         }
     },
+    computed: {
+        ...authComputed,
+    },
     setup() {
         const store = useStore();
+        const totalPages = computed(() => store.state.records.totalPages);
+        const page = computed(() => store.state.records.page);
+
+        const createData = () => {
+            router.push({
+                path: "/records/write",
+            });
+        };
+
+
+        // 게시글 리스트 조회 함수 정의
+        const fetchData = (page: number) => {
+            const reqParam: RecordReqParam = { // To-Do 동적으로 요청 param 바뀌도록
+                page: page - 1,
+                part: 'all',
+                type: 'all',
+                category: null
+            };
+            store.dispatch('getRecordList', reqParam);
+        };
         const getRecord = (id: number) => {
             store.dispatch('getRecord', id);
         };
+        onMounted(() => {
+            fetchData(1);
+        })
         return {
             getRecord,
+            totalPages,
+            page,
+            createData,
+            fetchData,
         }
     }
 }
 </script>
 
 <style scoped>
-
 </style>

--- a/src/components/SideVar.vue
+++ b/src/components/SideVar.vue
@@ -44,8 +44,8 @@ export default {
         const reqParam : RecordReqParam = { // To-Do 동적으로 요청 param 바뀌도록
         page: 0,
         part : part,
-        type: 'tech',
-        category: 'disaster' // 이거 어떻게 처리할지 고민
+        type: 'all',
+        category: null // 이거 어떻게 처리할지 고민
       };
         store.dispatch('getRecordList', reqParam);
     }

--- a/src/store/modules/Auth.ts
+++ b/src/store/modules/Auth.ts
@@ -95,10 +95,12 @@ const authModule: Module<AuthState, any> = {
         }
         
       } catch (error) {
-        alert('토큰 재발급에 실패하셨습니다.');
         commit('setLoggedIn', false);
         commit('setAccessToken', '');
+        commit('setUserInfo', {});
         localStorage.removeItem('admin');
+        localStorage.removeItem('userInfo');
+        alert('토큰 재발급에 실패하셨습니다.');
       }
     },
     async getUserInfo({commit, state}) {

--- a/src/types/RecordType.ts
+++ b/src/types/RecordType.ts
@@ -71,5 +71,5 @@ export interface RecordReqParam {
     page : number;
     part : string;
     type: string;
-    category: string;
+    category: any;
 }

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -2,16 +2,6 @@
   <div class="col g-1" id="container">
     <record-list :records="records"></record-list>
     
-    <nav aria-label="Page navigation example" class="col-md-6">
-      <ul class="pagination justify-content-center">
-        <li class="page-item" v-for="idx in page" :key="idx"><a class="page-link" @click="fetchData(Number(idx))">{{ idx
-        }}</a></li>
-      </ul>
-
-    </nav>
-    <div class="col-md-6 text-start">
-      <button type="button" class="btn btn-outline-secondary me-2" @click="createData()" v-if="loggedIn">글쓰기</button>
-    </div>
   </div>
 </template>
 <script lang="ts">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,18 +1,7 @@
 <template>
-  <div class="row g-1" id="container">
+  <div class="row" id="container">
     <record-list :records="records"></record-list>
     <side-var :hotRecords="hotRecords"></side-var>
-    
-    <nav aria-label="Page navigation example" class="col-md-6">
-      <ul class="pagination justify-content-center">
-        <li class="page-item" v-for="idx in page" :key="idx"><a class="page-link" @click="fetchData(Number(idx))">{{ idx
-        }}</a></li>
-      </ul>
-
-    </nav>
-    <div class="col-md-6 text-start">
-      <button type="button" class="btn btn-outline-secondary me-2" @click="createData()" v-if="loggedIn">글쓰기</button>
-    </div>
   </div>
 </template>
 
@@ -34,33 +23,13 @@ export default {
   },
   computed: {
         ...authComputed,
-    },
+  },
   setup() {
     const store = useStore(); // store 객체 사용을 위해 선언
     const router = useRouter();
 
     const records = computed(() => store.state.records.contents); // 게시물 리스트 세팅
-    const totalPages = computed(() => store.state.records.totalPages);
-    const page = computed(() => store.state.records.page);
-
     const hotRecords = computed(() => store.state.records.hotRecords); // 금주의 핫 게시물 데이터 세팅
-
-    const createData = () => {
-      router.push({
-        path: "/records/write",
-      });
-    };
-
-    // 게시글 리스트 조회 함수 정의
-    const fetchData = (page: number) => {
-      const reqParam : RecordReqParam = { // To-Do 동적으로 요청 param 바뀌도록
-        page: page-1,
-        part : 'web',
-        type: 'tech',
-        category: 'disaster'
-      };
-      store.dispatch('getRecordList', reqParam);
-    };
 
     const getHotRecordList = () => {
         store.dispatch('getHotRecordList');
@@ -68,17 +37,11 @@ export default {
 
     // 페이지 렌더링 시, 실행되는 함수
     onMounted(() => {
-      const id = 1;
-      fetchData(id);
       getHotRecordList();
     });
 
     return {
       records,
-      totalPages,
-      page,
-      fetchData,
-      createData,
       hotRecords
     };
 
@@ -95,5 +58,6 @@ export default {
 #container {
   margin-left: 100px;
   margin-right: 100px;
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
## 작업 내용

- CSS 변경 ( 글로벌 및 컴포넌트 단위 )
- 토큰 재발급 실패 시, 로컬 스토리지 데이터 전체 삭제 및 state 초기화
- 푸터 불필요한 링크 제거
- 메인 페이지 게시글 데이터 전체 조회를 위해 category타입 string-> any로 변경 ( null 허용을 위함 )
- type 별 게시글 리스트 조회 페이지에서도 컴포넌트 재사용을 위해 record-list 컴포넌트 구조 변경